### PR TITLE
Update readme and English version of the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The plugin is developed to support the evaluation of a course. It provides "stud
 
 When learners click on this type of work material, they are shown a configurable description. There are also two buttons: on the one hand, a button to view the anonymized log data available for download. A second button allows to download this data as a file. The log data does not contain any names of persons, and the user ID has also been removed. Therefore, it is not possible to draw any conclusions about the respective person from the data. The downloaded log file has the extension .kib3. Therefore, if you want to check the contents of such a .kib3 file, simply change the extension to .zip and unzip it.
 
+More details on functionality and configuration of this plugin can be found in the [Wiki](https://github.com/SE-Stuttgart/kib3_moodleplugin_srg/wiki).
 
 ## German Description
 
@@ -17,22 +18,23 @@ Das Plugin wurde entwickelt, um die Evaluation eines Kurses zu unterstützen. Es
 
 Wenn die Lernenden auf diese Art von Arbeitsmaterial klicken, wird ihnen eine konfigurierbare Beschreibung angezeigt. Außerdem gibt es zwei Schaltflächen: zum einen eine Schaltfläche, um die anonymisierten Protokolldaten, die zum Download bereitstehen, anzusehen. Eine zweite Schaltfläche ermöglicht es, diese Daten als Datei herunterzuladen. Die Protokolldaten enthalten keine Personennamen, und auch die Benutzer-ID wurde entfernt. Daher ist es nicht möglich, aus den Daten Rückschlüsse auf die jeweilige Person zu ziehen. Die heruntergeladene Protokolldatei hat die Endung .kib3. Wenn Sie also den Inhalt einer solchen .kib3-Datei überprüfen wollen, ändern Sie einfach die Endung in .zip und entpacken Sie sie.
 
-
+Mehr Informationen zu den Funktionen und zur Konfiguration des Plugins sind im [Wiki](https://github.com/SE-Stuttgart/kib3_moodleplugin_srg/wiki) zu finden.
  
 
 
 
 ### Installing via Uploaded ZIP File ##
 
-1. Log in to your Moodle site as an admin and go to _Site administration >
+1. Load the ZIP file with the newest version from [https://github.com/SE-Stuttgart/kib3_moodleplugin_srg/releases](https://github.com/SE-Stuttgart/kib3_moodleplugin_srg/releases).
+2. Log in to your Moodle site as an admin and go to _Site administration >
    Plugins > Install plugins_.
-2. Upload the ZIP file with the plugin code. You should only be prompted to add
+3. Upload the ZIP file with the plugin code. You should only be prompted to add
    extra details if your plugin type is not automatically detected.
-3. Check the plugin validation report and finish the installation.
+4. Check the plugin validation report and finish the installation.
 
 ## Installing Manually ##
 
-The plugin can be also installed by putting the contents of this directory to
+The plugin can also be installed by putting the contents of this directory to
 
     {your/moodle/dirroot}/mod/srg
 
@@ -49,7 +51,7 @@ to complete the installation from the command line.
 
 ## License ##
 
-2022 Universtity of Stuttgart <kasra.habib@iste.uni-stuttgart.de>
+2022 University of Stuttgart <kasra.habib@iste.uni-stuttgart.de>
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/lang/en/srg.php
+++ b/lang/en/srg.php
@@ -52,9 +52,9 @@ $string['error_creating_csv_file'] = 'There was an error creating the .csv file.
 $string['info_title'] = 'Data Overview';
 $string['info_heading'] = 'Data Overview';
 $string['content_title'] = 'Instructions';
-$string['content_default'] = 'Here you can view part of your anonymized log data in this Moodle course, or download it. <br><br>
-Hint: the downloaded file is actually a file in .zip format.
-It is however downloaded with .kib3 as extension, to prevent automatic unpacking by your operating system.
+$string['content_default'] = 'Here, you can view part of your anonymized log data in this Moodle course or download it if needed. <br><br>
+Hint: The downloaded file is actually a file in the .zip format.
+It is, however, downloaded with .kib3 as the extension to prevent automatic unpacking by your operating system.
 If you want to unpack and view it, please change the extension to .zip after downloading and then unpack it.';
 
 /**


### PR DESCRIPTION
**Summary**
The plugin install worked without issue. I was able to add the report generation as an activity and see my activities in the course. I suggest a few small changes and have some open points mentioned below.

**Open Points**
- During install, you get a warning that the plugin is still in beta: (should probably be updated before submitting the plugin)﻿
![Screenshot_20230111_163857](https://user-images.githubusercontent.com/29149798/212936165-abf76fc1-377b-4dc7-b798-d10e05a2210a.png)
- The current Github release (1.0) is not up-to-date. Currently, you need to download the repository to get the correct version.
- Who will use this plugin? Will they know what the columns in the report mean? For example, what does "dedication" mean? Or what do the different events mean? Otherwise, it might be helpful to explain the variables in the wiki.

